### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/acceptance-lts.yml
+++ b/.github/workflows/acceptance-lts.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Gateway branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk
@@ -31,7 +31,7 @@ jobs:
           path: ./tyk
 
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.0.2
         with:
           go-version: 1.16   # LTS (replace with golang-cross)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,14 @@ jobs:
 
     steps:
       - name: Checkout of tyk
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           repository: TykTechnologies/tyk
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 1
 
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.0.2
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/exp-cmd.yml
+++ b/.github/workflows/exp-cmd.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.0.2
         with:
           go-version: '1.21.x'
 

--- a/.github/workflows/modcheck.yml
+++ b/.github/workflows/modcheck.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -69,12 +69,12 @@ jobs:
           echo "GOTOOLCHAIN=local" >> $GITHUB_ENV
 
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.0.2
         with:
           go-version: ${{ inputs.goVersion }}
 
       - name: 'Extract tykio/ci-tools:latest'
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@v3.0.1
         with:
           image: tykio/ci-tools:latest
           path: /usr/local/bin/.
@@ -85,7 +85,7 @@ jobs:
         run: task
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           repository: ${{ github.event.inputs.repository }}
           token: ${{ secrets.ORG_GH_TOKEN }}
@@ -129,7 +129,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Raise PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7.0.5
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Import updated go.mod/go.sum

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -70,19 +70,19 @@ jobs:
           echo "jira=${{ needs.sanitize.outputs.jira }}" >> $GITHUB_ENV
 
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.0.2
         with:
           go-version: '1.21.x'
 
       - name: 'Extract tykio/ci-tools:latest'
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@v3.0.1
         with:
           image: tykio/ci-tools:latest
           path: /usr/local/bin/.
           destination: /usr/local/bin
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           repository: ${{ github.event.inputs.repository }}
           token: ${{ secrets.ORG_GH_TOKEN }}
@@ -117,7 +117,7 @@ jobs:
         run: echo "Last ran on $(date) by @${{ github.actor }}" > ci-semgrep.txt
 
       - name: Raise PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7.0.5
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Semgrep scan result

--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Gateway
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk
@@ -140,7 +140,7 @@ jobs:
           path: ./tyk
 
       - name: 'Extract tykio/ci-tools:latest'
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@v3.0.1
         with:
           image: tykio/ci-tools:latest
           path: /usr/local/bin/.
@@ -165,7 +165,7 @@ jobs:
           cp ./tyk/swagger.yml gateway-docs/gateway-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.1
         with:
           name: gateway-docs
           path: gateway-docs
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dashboard
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 1
@@ -192,7 +192,7 @@ jobs:
           cp ./tyk-analytics/swagger-admin.yml dashboard-docs/dashboard-admin-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.1
         with:
           name: dashboard-docs
           path: dashboard-docs
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout MDCB
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 1
@@ -218,7 +218,7 @@ jobs:
           cp ./tyk-sink/swagger.yml mdcb-docs/mdcb-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.1
         with:
           name: mdcb-docs
           path: mdcb-docs
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Config Generator
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           repository: TykTechnologies/tyk-config-info-generator
           path: ./tyk-config-info-generator
@@ -287,7 +287,7 @@ jobs:
           cp /node/home/tyk-config-info-generator/info/$branch/$repo.md $dest
 
       - name: Store docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.1
         with:
           name: config-docs
           path: config-docs
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
 
       - name: Set up env
         run: |
@@ -307,7 +307,7 @@ jobs:
              echo "target=${{ needs.sanitize.outputs.docsBranch }}" >> $GITHUB_ENV
 
       - name: Checkout Docs
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk-docs
@@ -323,7 +323,7 @@ jobs:
              [ -d "config-docs" ]    && cp config-docs/* ./tyk-docs/tyk-docs/content/shared/
 
       - name: Raise tyk-docs PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7.0.5
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Import config/docs

--- a/.github/workflows/update-gh-actions.yml
+++ b/.github/workflows/update-gh-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ORG_GH_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.1](https://github.com/actions/checkout/releases/tag/v4.2.1)** on 2024-10-07T16:44:53Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.5](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.5)** on 2024-09-18T17:41:45Z
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v5.0.2](https://github.com/actions/setup-go/releases/tag/v5.0.2)** on 2024-07-10T13:51:42Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.4.1](https://github.com/actions/upload-artifact/releases/tag/v4.4.1)** on 2024-10-07T15:47:34Z
* **[shrink/actions-docker-extract](https://github.com/shrink/actions-docker-extract)** published a new release **[v3.0.1](https://github.com/shrink/actions-docker-extract/releases/tag/v3.0.1)** on 2024-09-06T20:28:58Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.8](https://github.com/actions/download-artifact/releases/tag/v4.1.8)** on 2024-07-05T15:12:41Z
