### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/acceptance-lts.yml
+++ b/.github/workflows/acceptance-lts.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Gateway branch
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk
@@ -31,7 +31,7 @@ jobs:
           path: ./tyk
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.0.2
+        uses: actions/setup-go@v5.1.0
         with:
           go-version: 1.16   # LTS (replace with golang-cross)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,14 @@ jobs:
 
     steps:
       - name: Checkout of tyk
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           repository: TykTechnologies/tyk
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 1
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.0.2
+        uses: actions/setup-go@v5.1.0
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/exp-cmd.yml
+++ b/.github/workflows/exp-cmd.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.0.2
+        uses: actions/setup-go@v5.1.0
         with:
           go-version: '1.21.x'
 

--- a/.github/workflows/modcheck.yml
+++ b/.github/workflows/modcheck.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -69,7 +69,7 @@ jobs:
           echo "GOTOOLCHAIN=local" >> $GITHUB_ENV
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.0.2
+        uses: actions/setup-go@v5.1.0
         with:
           go-version: ${{ inputs.goVersion }}
 
@@ -85,7 +85,7 @@ jobs:
         run: task
 
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           repository: ${{ github.event.inputs.repository }}
           token: ${{ secrets.ORG_GH_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -70,7 +70,7 @@ jobs:
           echo "jira=${{ needs.sanitize.outputs.jira }}" >> $GITHUB_ENV
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.0.2
+        uses: actions/setup-go@v5.1.0
         with:
           go-version: '1.21.x'
 
@@ -82,7 +82,7 @@ jobs:
           destination: /usr/local/bin
 
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           repository: ${{ github.event.inputs.repository }}
           token: ${{ secrets.ORG_GH_TOKEN }}

--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Gateway
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk
@@ -165,7 +165,7 @@ jobs:
           cp ./tyk/swagger.yml gateway-docs/gateway-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.1
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: gateway-docs
           path: gateway-docs
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dashboard
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 1
@@ -192,7 +192,7 @@ jobs:
           cp ./tyk-analytics/swagger-admin.yml dashboard-docs/dashboard-admin-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.1
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: dashboard-docs
           path: dashboard-docs
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout MDCB
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 1
@@ -218,7 +218,7 @@ jobs:
           cp ./tyk-sink/swagger.yml mdcb-docs/mdcb-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.1
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: mdcb-docs
           path: mdcb-docs
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Config Generator
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           repository: TykTechnologies/tyk-config-info-generator
           path: ./tyk-config-info-generator
@@ -287,7 +287,7 @@ jobs:
           cp /node/home/tyk-config-info-generator/info/$branch/$repo.md $dest
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.1
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: config-docs
           path: config-docs
@@ -307,7 +307,7 @@ jobs:
              echo "target=${{ needs.sanitize.outputs.docsBranch }}" >> $GITHUB_ENV
 
       - name: Checkout Docs
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk-docs

--- a/.github/workflows/update-gh-actions.yml
+++ b/.github/workflows/update-gh-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ORG_GH_TOKEN }}

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -73,7 +73,7 @@ jobs:
           destination: /usr/local/bin
 
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           repository: ${{ github.event.inputs.repository }}
           token: ${{ secrets.ORG_GH_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.4.3](https://github.com/actions/upload-artifact/releases/tag/v4.4.3)** on 2024-10-09T17:17:34Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v5.1.0](https://github.com/actions/setup-go/releases/tag/v5.1.0)** on 2024-10-24T14:24:50Z
