### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/acceptance-lts.yml
+++ b/.github/workflows/acceptance-lts.yml
@@ -31,7 +31,7 @@ jobs:
           path: ./tyk
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@v5.2.0
         with:
           go-version: 1.16   # LTS (replace with golang-cross)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@v5.2.0
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/exp-cmd.yml
+++ b/.github/workflows/exp-cmd.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@v5.2.0
         with:
           go-version: '1.21.x'
 

--- a/.github/workflows/modcheck.yml
+++ b/.github/workflows/modcheck.yml
@@ -69,7 +69,7 @@ jobs:
           echo "GOTOOLCHAIN=local" >> $GITHUB_ENV
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@v5.2.0
         with:
           go-version: ${{ inputs.goVersion }}
 
@@ -129,7 +129,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Raise PR
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@v7.0.6
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Import updated go.mod/go.sum

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -70,7 +70,7 @@ jobs:
           echo "jira=${{ needs.sanitize.outputs.jira }}" >> $GITHUB_ENV
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@v5.2.0
         with:
           go-version: '1.21.x'
 
@@ -117,7 +117,7 @@ jobs:
         run: echo "Last ran on $(date) by @${{ github.actor }}" > ci-semgrep.txt
 
       - name: Raise PR
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@v7.0.6
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Semgrep scan result

--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -165,7 +165,7 @@ jobs:
           cp ./tyk/swagger.yml gateway-docs/gateway-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: gateway-docs
           path: gateway-docs
@@ -192,7 +192,7 @@ jobs:
           cp ./tyk-analytics/swagger-admin.yml dashboard-docs/dashboard-admin-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: dashboard-docs
           path: dashboard-docs
@@ -218,7 +218,7 @@ jobs:
           cp ./tyk-sink/swagger.yml mdcb-docs/mdcb-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: mdcb-docs
           path: mdcb-docs
@@ -287,7 +287,7 @@ jobs:
           cp /node/home/tyk-config-info-generator/info/$branch/$repo.md $dest
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: config-docs
           path: config-docs
@@ -323,7 +323,7 @@ jobs:
              [ -d "config-docs" ]    && cp config-docs/* ./tyk-docs/tyk-docs/content/shared/
 
       - name: Raise tyk-docs PR
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@v7.0.6
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Import config/docs

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -97,7 +97,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Raise PR
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@v7.0.6
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Workflow lint autofix


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v5.2.0](https://github.com/actions/setup-go/releases/tag/v5.2.0)** on 2024-12-11T03:21:32Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.0](https://github.com/actions/upload-artifact/releases/tag/v4.6.0)** on 2025-01-09T15:47:07Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.6](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.6)** on 2024-12-27T11:02:42Z
