### PR TITLE
allow the user to strip some package prefixes

### DIFF
--- a/cmd/schema-gen/jsonschema/options.go
+++ b/cmd/schema-gen/jsonschema/options.go
@@ -10,18 +10,20 @@ type options struct {
 	sourcePath string
 	rootType   string
 	outputFile string
+	stripPrefix []string
 }
 
 func NewOptions() *options {
 	cfg := &options{
 		sourcePath: ".",
 		outputFile: "schema.json",
+		stripPrefix: []string{},
 	}
 
 	pflag.StringVarP(&cfg.sourcePath, "dir", "i", cfg.sourcePath, "Path to the directory that contains the root type (required)")
 	pflag.StringVarP(&cfg.rootType, "type", "t", cfg.rootType, "Root type to generate schema for (required)")
 	pflag.StringVarP(&cfg.outputFile, "out", "o", cfg.outputFile, "Output file name (optional)")
-
+	pflag.StringSliceVarP(&cfg.stripPrefix, "strip-prefix", "s", cfg.stripPrefix, "List of package prefixes to strip from definition names (optional)")
 	pflag.Parse()
 
 	return cfg

--- a/cmd/schema-gen/jsonschema/run.go
+++ b/cmd/schema-gen/jsonschema/run.go
@@ -14,5 +14,5 @@ func Run() (err error) {
 		return nil
 	}
 
-	return ParseAndConvertStruct(cfg.sourcePath, cfg.rootType, cfg.outputFile)
+	return ParseAndConvertStruct(cfg.sourcePath, cfg.rootType, cfg.outputFile,cfg.stripPrefix)
 }


### PR DESCRIPTION
For  extenal fields like apidef.User. we produce ApiDefUser  to avoid collision. However sometime you might want it to be just User since no other package has the User struct so they would be no collision.

To do this we have added a new  --strip-prefix that accepts a list of prefix you dont want append .E.g you can write:

schema-gen jsonschema -i=/Users/itachisasuke/projects/schema-test/. -t=User -s=apidef,model

Now all the structs in apidef and model will not have the prefix