### PR TITLE
Adjusted title of x-tyk-gateway doc

### DIFF
--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -154,7 +154,7 @@ jobs:
           schema-gen extract -o - | schema-gen markdown -i - \
                                                         --root XTykAPIGateway \
                                                         --skip "OldOAS,APIDef,OAS,TykExtensionConfigParams" \
-                                                        --title "## Tyk OAS API Definition Object" \
+                                                        --title "## Tyk vendor extension reference" \
                                                         --replace "model.ObjectID=string,apidef.MiddlewareDriver=string,apidef.IdExtractorSource=string,apidef.IdExtractorType=string,apidef.RequestInputType=string,apidef.AuthTypeEnum=string,[]osin.AuthorizeRequestType=[]string" \
                                                         --heading-format "### **%s**" \
                                                         --trim "Tyk classic API definition" \


### PR DESCRIPTION
Rename the auto-generated documentation of x-tyk-api-gateway object: this is not the Tyk OAS API definition, but is only a part of that (the Tyk vendor extension).