### PR TITLE
security: pin all actions to SHA, images to digest, add dep-guard

### DIFF
--- a/.github/Taskfile.yml
+++ b/.github/Taskfile.yml
@@ -20,7 +20,9 @@ tasks:
     status:
       - type actionlint
     cmds:
-      - go install github.com/rhysd/actionlint/cmd/actionlint@latest
+      - |
+        VERSION=v1.7.7
+        go install github.com/rhysd/actionlint/cmd/actionlint@${VERSION}
 
   install:shellcheck:
     desc: Install shellcheck

--- a/.github/workflows/acceptance-lts.yml
+++ b/.github/workflows/acceptance-lts.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Gateway branch
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk
@@ -31,7 +31,7 @@ jobs:
           path: ./tyk
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
         with:
           go-version: 1.16   # LTS (replace with golang-cross)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,14 @@ jobs:
 
     steps:
       - name: Checkout of tyk
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: TykTechnologies/tyk
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 1
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Build repository list
         id: build-repo-list
@@ -121,7 +121,7 @@ jobs:
 
       - name: Send Slack notification
         if: ${{ github.event.inputs.notify_slack == 'true' }}
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001  # v1.25.0
         with:
           channel-id: '#team-ext-engineering-pr-notifications'
           slack-message: |

--- a/.github/workflows/create-tags.yml
+++ b/.github/workflows/create-tags.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Build repository list
         id: build-repo-list
@@ -156,7 +156,7 @@ jobs:
           done
 
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001  # v1.25.0
         with:
           channel-id: '#team-ext-engineering-pr-notifications'
           slack-message: |

--- a/.github/workflows/exp-cmd.yml
+++ b/.github/workflows/exp-cmd.yml
@@ -52,6 +52,6 @@ jobs:
         uses: ./.github/actions/github-sync
         if: github.event_name == 'push'
         with:
-          repository: TykTechnologies/github-actions
+          repository: TykTechnologies/github-actions # dispatch-target
           eventType: exp-cmd
           token: ${{ secrets.ORG_GH_TOKEN }}

--- a/.github/workflows/exp-cmd.yml
+++ b/.github/workflows/exp-cmd.yml
@@ -22,17 +22,23 @@ on:  # yamllint disable-line rule:truthy
       - go.sum
 
 jobs:
+  dependency-guard:
+    if: github.event_name == 'pull_request'
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@d3fa20888fa2878e877e22bb7702141217290e7c  # main
+
   exp-cmd-build:
+    needs: [dependency-guard]
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout PR
-        uses: TykTechnologies/exp/.github/actions/checkout-pr@main
+        uses: TykTechnologies/exp/.github/actions/checkout-pr@49245597f0620ef8460735bb0ae6e93be5f8ca51  # main
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
         with:
           go-version: '1.21.x'
 

--- a/.github/workflows/modcheck.yml
+++ b/.github/workflows/modcheck.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -72,19 +72,19 @@ jobs:
           echo "GOTOOLCHAIN=local" >> $GITHUB_ENV
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
         with:
           go-version: ${{ github.event.inputs.goversion }}
 
       - name: 'Extract tykio/ci-tools:latest'
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@04c17c51a5b9fd93b7aed2e05e86c8fe2d90ee52  # v3.0.1
         with:
           image: tykio/ci-tools:latest
           path: /usr/local/bin/.
           destination: /usr/local/bin
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: ${{ github.event.inputs.repository }}
           token: ${{ secrets.ORG_GH_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Raise PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Import updated go.mod/go.sum

--- a/.github/workflows/modcheck.yml
+++ b/.github/workflows/modcheck.yml
@@ -76,10 +76,10 @@ jobs:
         with:
           go-version: ${{ github.event.inputs.goversion }}
 
-      - name: 'Extract tykio/ci-tools:latest'
+      - name: 'Extract tykio/ci-tools'
         uses: shrink/actions-docker-extract@04c17c51a5b9fd93b7aed2e05e86c8fe2d90ee52  # v3.0.1
         with:
-          image: tykio/ci-tools:latest
+          image: tykio/ci-tools@sha256:50ed0ddf4e321c61cbacfd2bfacdd180fb0dbce0ce4da3ec264847354ab83c96
           path: /usr/local/bin/.
           destination: /usr/local/bin
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -70,19 +70,19 @@ jobs:
           echo "jira=${{ needs.sanitize.outputs.jira }}" >> $GITHUB_ENV
 
       - name: Setup Golang
-        uses: actions/setup-go@v5.1.0
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
         with:
           go-version: '1.21.x'
 
       - name: 'Extract tykio/ci-tools:latest'
-        uses: shrink/actions-docker-extract@v3.0.1
+        uses: shrink/actions-docker-extract@f97780187d59e88f06a98b166a7e700c0f400314  # v3.0.1
         with:
           image: tykio/ci-tools:latest
           path: /usr/local/bin/.
           destination: /usr/local/bin
 
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: ${{ github.event.inputs.repository }}
           token: ${{ secrets.ORG_GH_TOKEN }}
@@ -117,7 +117,7 @@ jobs:
         run: echo "Last ran on $(date) by @${{ github.actor }}" > ci-semgrep.txt
 
       - name: Raise PR
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Semgrep scan result

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -74,10 +74,10 @@ jobs:
         with:
           go-version: '1.21.x'
 
-      - name: 'Extract tykio/ci-tools:latest'
+      - name: 'Extract tykio/ci-tools'
         uses: shrink/actions-docker-extract@f97780187d59e88f06a98b166a7e700c0f400314  # v3.0.1
         with:
-          image: tykio/ci-tools:latest
+          image: tykio/ci-tools@sha256:50ed0ddf4e321c61cbacfd2bfacdd180fb0dbce0ce4da3ec264847354ab83c96
           path: /usr/local/bin/.
           destination: /usr/local/bin
 

--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Gateway
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk
@@ -156,13 +156,13 @@ jobs:
           path: ./tyk
 
       - name: Checkout exp
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
           path: ./exp
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
         with:
           go-version: "1.21"
 
@@ -212,7 +212,7 @@ jobs:
 
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: gateway-docs
           path: gateway-docs
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dashboard
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 1
@@ -262,7 +262,7 @@ jobs:
           cp ./tyk-analytics/docs/opa/opa-rules.md dashboard-docs/opa-rules.mdx
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: dashboard-docs
           path: dashboard-docs
@@ -275,7 +275,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout MDCB
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 1
@@ -289,7 +289,7 @@ jobs:
           cp ./tyk-sink/swagger.yml mdcb-docs/mdcb-swagger.yml
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: mdcb-docs
           path: mdcb-docs
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Portal
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 1
@@ -316,7 +316,7 @@ jobs:
           cp ./portal/docs/api/enterprise-developer-portal-swagger.yaml portal-docs/enterprise-developer-portal-swagger.yaml
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: portal-docs
           path: portal-docs
@@ -328,7 +328,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Config Generator
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: TykTechnologies/tyk-config-info-generator
           path: ./tyk-config-info-generator
@@ -386,7 +386,7 @@ jobs:
           cp /node/home/tyk-config-info-generator/info/$branch/$repo.md $dest
 
       - name: Store docs
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: config-docs
           path: config-docs
@@ -398,10 +398,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore artifacts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
 
       - name: Checkout exp repo (for cleanup script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           path: ./exp  # this repo where your Python script lives
 
@@ -422,7 +422,7 @@ jobs:
              echo "target=${{ needs.sanitize.outputs.docsBranch }}" >> $GITHUB_ENV
 
       - name: Checkout Docs
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
           repository: TykTechnologies/tyk-docs
@@ -441,7 +441,7 @@ jobs:
              true
 
       - name: Raise tyk-docs PR
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Import config/docs

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -65,10 +65,10 @@ jobs:
         run: |
           echo "jira=${{ needs.sanitize.outputs.jira }}" >> $GITHUB_ENV
 
-      - name: 'Extract tykio/ci-tools:latest'
+      - name: 'Extract tykio/ci-tools'
         uses: shrink/actions-docker-extract@f97780187d59e88f06a98b166a7e700c0f400314  # v3.0.1
         with:
-          image: tykio/ci-tools:latest
+          image: tykio/ci-tools@sha256:50ed0ddf4e321c61cbacfd2bfacdd180fb0dbce0ce4da3ec264847354ab83c96
           path: /usr/local/bin/workflow-lint
           destination: /usr/local/bin
 

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -66,14 +66,14 @@ jobs:
           echo "jira=${{ needs.sanitize.outputs.jira }}" >> $GITHUB_ENV
 
       - name: 'Extract tykio/ci-tools:latest'
-        uses: shrink/actions-docker-extract@v3.0.1
+        uses: shrink/actions-docker-extract@f97780187d59e88f06a98b166a7e700c0f400314  # v3.0.1
         with:
           image: tykio/ci-tools:latest
           path: /usr/local/bin/workflow-lint
           destination: /usr/local/bin
 
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: ${{ github.event.inputs.repository }}
           token: ${{ secrets.ORG_GH_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Raise PR
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           commit-message: Workflow lint autofix

--- a/.taskfiles/install/Taskfile.yml
+++ b/.taskfiles/install/Taskfile.yml
@@ -13,11 +13,15 @@ tasks:
     status:
      - type gotestsum
     cmds:
-      - go install github.com/wadey/gocovmerge@latest
+      - |
+        VERSION=v0.0.0-20160331181800-b5bfa59ec0ad
+        go install github.com/wadey/gocovmerge@${VERSION}
 
   gotestsum:
     internal: true
     status:
       - type gotestsum
     cmds:
-      - go install gotest.tools/gotestsum@latest
+      - |
+        VERSION=v1.12.3
+        go install gotest.tools/gotestsum@${VERSION}

--- a/.taskfiles/lint.yml
+++ b/.taskfiles/lint.yml
@@ -18,7 +18,9 @@ tasks:
     status:
       - type actionlint
     cmds:
-      - go install github.com/rhysd/actionlint/cmd/actionlint@latest
+      - |
+        VERSION=v1.7.7
+        go install github.com/rhysd/actionlint/cmd/actionlint@${VERSION}
 
   install:shellcheck:
     desc: Install shellcheck

--- a/cmd/httpbin-logserver/Dockerfile
+++ b/cmd/httpbin-logserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 ADD ./httpbin-logserver /
 

--- a/cmd/summary/Dockerfile
+++ b/cmd/summary/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 ADD ./summary /
 

--- a/pkg/model/Taskfile.yml
+++ b/pkg/model/Taskfile.yml
@@ -44,4 +44,6 @@ tasks:
     status:
       - type schema-gen
     cmds:
-      - go install github.com/TykTechnologies/exp/cmd/schema-gen@latest
+      - |
+        VERSION=v0.0.0-20260407114521-8eb6424dfe10
+        go install github.com/TykTechnologies/exp/cmd/schema-gen@${VERSION}

--- a/scripts/model2schema/Taskfile.yml
+++ b/scripts/model2schema/Taskfile.yml
@@ -66,7 +66,9 @@ tasks:
   install:
     desc: "Install deps"
     cmds:
-      - go install github.com/homeport/dyff/cmd/dyff@latest
+      - |
+        VERSION=v1.11.3
+        go install github.com/homeport/dyff/cmd/dyff@${VERSION}
 
   update:
     desc: "Update schema-gen dependency"

--- a/tests/plugins-rhel8/Dockerfile
+++ b/tests/plugins-rhel8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.04@sha256:1f1a2d56de1d604801a9671f301190704c25d604a416f59e03c04f5c6ffee0d6
 
 USER root
 


### PR DESCRIPTION
## Summary
- **Pin all GitHub Actions** across 9 workflows to full commit SHA (prevents tag-hijack supply chain attacks)
- **Pin Docker base images** (`alpine:latest`, `ubuntu:16.04`) to digest in 3 Dockerfiles
- **Add dependency-guard** reusable workflow to `exp-cmd.yml` (PR-triggered builds)
- **Normalize action versions** to latest known patch (e.g. `@v4` -> `@v4.2.2`, `@v5` -> `@v5.1.0`)
- **TykTechnologies/github-actions** ref pinned to `d3fa20888fa2878e877e22bb7702141217290e7c` (main)

### Actions pinned (SHA)
| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4.2.2 | `11bd71901bbe5b1630ceea73d27597364c9af683` |
| `actions/setup-go` | v5.1.0 | `41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed` |
| `actions/upload-artifact` | v4.4.3 | `b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882` |
| `actions/download-artifact` | v4.1.8 | `fa0a91b85d4f404e444e00e005971372dc801d16` |
| `peter-evans/create-pull-request` | v7.0.5 | `5e914681df9dc83aa4e4905692ca88beb2f9e91f` |
| `shrink/actions-docker-extract` | v3.0.1 | `f97780187d59e88f06a98b166a7e700c0f400314` |
| `slackapi/slack-github-action` | v1.25.0 | `6c661ce58804a1a20f6dc5fbee7f0381b469e001` |
| `TykTechnologies/exp/...checkout-pr` | main | `49245597f0620ef8460735bb0ae6e93be5f8ca51` |

### Docker images pinned (digest)
| Image | Digest |
|-------|--------|
| `alpine:latest` | `sha256:25109184...` |
| `ubuntu:16.04` | `sha256:1f1a2d56...` |

### Scan results
- No `curl \| bash` or `curl \| sh` patterns found
- No `pip install` or `npm install` in workflows or Dockerfiles
- `go install .` in tyk-docs.yml installs from local source (safe)
- No npm ci in Dockerfiles

## Test plan
- [ ] Verify exp-cmd workflow runs on PR and dep-guard passes
- [ ] Verify workflow_dispatch workflows still trigger with SHA-pinned actions
- [ ] Verify Docker builds succeed with digest-pinned base images

Generated with [Claude Code](https://claude.com/claude-code)