### PR TITLE
test: use otel-metrics-config generator branch for tyk-docs workflow

### DIFF
--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -73,7 +73,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   GOPRIVATE: github.com/TykTechnologies
-  configInfoGeneratorBranch: main
+  configInfoGeneratorBranch: fix/otel-metrics-config
 
 jobs:
   sanitize:


### PR DESCRIPTION
## Summary
- Points `configInfoGeneratorBranch` to `fix/otel-metrics-config` to test the generator fix that adds missing OpenTelemetry metrics/traces config to generated docs
- Related generator PR: TykTechnologies/tyk-config-info-generator#14

## After testing
Revert this PR (or just close it) once the generator PR is merged to `main`.