### PR TITLE
[TT-16831] Use config generator branch with deprecated field support

### DIFF
--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -73,7 +73,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   GOPRIVATE: github.com/TykTechnologies
-  configInfoGeneratorBranch: main
+  configInfoGeneratorBranch: TT-16831/docs
 
 jobs:
   sanitize:


### PR DESCRIPTION
## Summary
- Points `configInfoGeneratorBranch` to `TT-16831/docs` to test the config generator changes that propagate `Deprecated:` notices from inline embeds to child fields
- See TykTechnologies/tyk-config-info-generator#15

## Notes
- This is temporary — once the generator PR is merged to `main`, this should be reverted back to `configInfoGeneratorBranch: main`
- Allows running the tyk-docs workflow to verify that root-level `opentelemetry.*` fields show deprecation warnings while `opentelemetry.traces.*` fields remain clean

## Test plan
- [ ] Run the tyk-docs workflow from this branch with Gateway sync enabled
- [ ] Verify generated `gateway-config.mdx` has `<Warning>` blocks on `opentelemetry.enabled`, `opentelemetry.exporter`, etc.
- [ ] Verify `opentelemetry.traces.*` fields have no deprecation warnings