### PR TITLE
[TT-17030] Migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -34,9 +34,6 @@ on:  # yamllint disable-line rule:truthy
         type: boolean
         default: false
 
-env:
-  GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
-
 jobs:
   create-branches:
     name: Create branches in selected repositories
@@ -44,6 +41,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
 
       - name: Build repository list
         id: build-repo-list
@@ -91,7 +96,7 @@ jobs:
 
       - name: Create branches
         env:
-          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SOURCE_BRANCH: ${{ github.event.inputs.source_branch }}
           DEST_BRANCH: ${{ github.event.inputs.destination_branch }}
         run: |

--- a/.github/workflows/create-tags.yml
+++ b/.github/workflows/create-tags.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Build repository list
         id: build-repo-list
         run: |
@@ -99,7 +107,7 @@ jobs:
 
       - name: Create tags
         env:
-          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SOURCE_BRANCH: ${{ github.event.inputs.source_branch }}
           TAG_NAME: ${{ github.event.inputs.tag_name }}
           TAG_MESSAGE: ${{ github.event.inputs.tag_message }}

--- a/.github/workflows/exp-cmd.yml
+++ b/.github/workflows/exp-cmd.yml
@@ -32,10 +32,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Checkout PR
         uses: TykTechnologies/exp/.github/actions/checkout-pr@49245597f0620ef8460735bb0ae6e93be5f8ca51  # main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Golang
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5.1.0
@@ -54,4 +62,4 @@ jobs:
         with:
           repository: TykTechnologies/github-actions # dispatch-target
           eventType: exp-cmd
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` (PAT) with GitHub App token generation using `actions/create-github-app-token` in remaining workflow files
- Migrated files: `code-freeze.yml`, `create-tags.yml`, `exp-cmd.yml`
- Each job gets its own `app-token` step that generates a token using `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` secrets
- Also removed the top-level `env.GITHUB_TOKEN` from `code-freeze.yml` that referenced ORG_GH_TOKEN

## Test plan
- [ ] Verify `code-freeze.yml` workflow can create branches across repositories using the app token
- [ ] Verify `create-tags.yml` workflow can create tags using the app token
- [ ] Verify `exp-cmd.yml` builds and dispatches events using the app token
- [ ] Confirm `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` secrets are configured in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)