### PR TITLE
[TT-17030] Fix code-freeze git auth with GitHub App token

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -100,17 +100,21 @@ jobs:
           SOURCE_BRANCH: ${{ github.event.inputs.source_branch }}
           DEST_BRANCH: ${{ github.event.inputs.destination_branch }}
         run: |
+          # Configure git to use the app token for all github.com access
+          # This overrides any credential helpers set by actions/checkout
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
           # Get repositories as JSON array
           REPOSITORIES='${{ steps.build-repo-list.outputs.repositories }}'
-          
+
           # Loop through each repository
           echo "$REPOSITORIES" | jq -c '.[]' | while read -r repo; do
             # Remove quotes from repo name
             repo=$(echo "$repo" | tr -d '"')
             echo "Creating branch for repository: $repo"
-            
+
             # Clone repository
-            git clone --depth 1 --branch "$SOURCE_BRANCH" "https://$GH_TOKEN@github.com/TykTechnologies/$repo.git"
+            git clone --depth 1 --branch "$SOURCE_BRANCH" "https://github.com/TykTechnologies/$repo.git"
             cd "$repo"
             
             # Create and push new branch


### PR DESCRIPTION
## Problem
Code Freeze workflow fails with:
```
fatal: could not read Password for 'https://***@github.com': No such device or address
```

The `actions/checkout` step sets a git credential helper for `github.com`. When `git clone https://$GH_TOKEN@github.com/...` runs later, the credential helper intercepts the request and overrides the token in the URL, causing auth failure.

## Fix
Use `git config --global url.insteadOf` to rewrite all `https://github.com/` URLs to include the app token as `x-access-token`. This takes precedence over credential helpers and is the standard pattern for GitHub App tokens.

## Failing run
https://github.com/TykTechnologies/exp/actions/runs/24825227262/job/72659328585

🤖 Generated with [Claude Code](https://claude.com/claude-code)