### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/modcheck.yml
+++ b/.github/workflows/modcheck.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           TOKEN: '${{ steps.app-token.outputs.token }}'
         run: >
-          git config --global url."https://${TOKEN}@github.com/TykTechnologies".insteadOf "https://github.com/TykTechnologies"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/TykTechnologies".insteadOf "https://github.com/TykTechnologies"
 
       - working-directory: ./tyk
         run: go mod download

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -101,7 +101,7 @@ jobs:
         env:
           TOKEN: '${{ steps.app-token.outputs.token }}'
         run: >
-          git config --global url."https://${TOKEN}@github.com/TykTechnologies".insteadOf "https://github.com/TykTechnologies"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/TykTechnologies".insteadOf "https://github.com/TykTechnologies"
 
       - working-directory: ./lsc/semgrep
         id: semgrep_run

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           TOKEN: '${{ steps.app-token.outputs.token }}'
         run: >
-          git config --global url."https://${TOKEN}@github.com/TykTechnologies".insteadOf "https://github.com/TykTechnologies"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/TykTechnologies".insteadOf "https://github.com/TykTechnologies"
 
       - name: Run workflow-lint --fix
         id: lint_run


### PR DESCRIPTION
## Summary
- Fix `git config insteadOf` pattern in `modcheck.yml`, `semgrep.yml`, and `workflow-lint.yml` to use `x-access-token:` prefix
- These files use an org-scoped pattern (`github.com/TykTechnologies`); the fix adds the `x-access-token:` prefix while preserving the org scope
- The bare token pattern fails when `actions/checkout` has set up a credential helper; the `x-access-token:` prefix ensures the URL rewrite takes precedence
- Note: `code-freeze.yml` already uses the correct pattern and was not modified

## Files changed
- `.github/workflows/modcheck.yml` — 1 replacement
- `.github/workflows/semgrep.yml` — 1 replacement
- `.github/workflows/workflow-lint.yml` — 1 replacement

## Test plan
- [ ] Verify modcheck, semgrep, and workflow-lint workflows resolve private Go module deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)