### PR TITLE
[TT-17214] Add tyk-identity-broker to create-tags workflow

### DIFF
--- a/.github/workflows/create-tags.yml
+++ b/.github/workflows/create-tags.yml
@@ -25,6 +25,7 @@ on:
           - 'tyk-charts'
           - 'portal'
           - 'tyk-pump'
+          - 'tyk-identity-broker'
           - 'governance-dashboard'
           - 'governance-agent'
         default: 'tyk-core-products'
@@ -74,6 +75,9 @@ jobs:
               ;;
             "tyk-pump")
               REPOS+=("tyk-pump")
+              ;;
+            "tyk-identity-broker")
+              REPOS+=("tyk-identity-broker")
               ;;
             "governance-dashboard")
               REPOS+=("governance-poc")


### PR DESCRIPTION
## Summary
- Adds `tyk-identity-broker` to the repository selection dropdown in `.github/workflows/create-tags.yml`
- Maps the selection to the `tyk-identity-broker` repo so release tags can be created via workflow dispatch
- Needed for the TIB 1.7.2 release prep

## Test plan
- [ ] Trigger the `Create Tags Across Repositories` workflow with `tyk-identity-broker` selected and verify the tag is created on the target repo