### PR TITLE
TT-17666: Handle missing packages gracefully and parameterize promote workflow

### DIFF
--- a/.github/workflows/promote-packages.yml
+++ b/.github/workflows/promote-packages.yml
@@ -123,10 +123,22 @@ jobs:
               return 0
             fi
 
-            curl -sf -X POST \
+            local tmp_res
+            tmp_res=$(mktemp)
+            local status_code
+            status_code=$(curl -s -S -o "$tmp_res" -w "%{http_code}" -X POST \
               -F "destination=tyk/${repo}" \
-              "https://${PACKAGECLOUD_TOKEN}:@packagecloud.io/api/v1/repos/tyk/${repo}-unstable/${distro}/${pkg_name}/promote.json" \
-              | jq -r .download_url
+              "https://${PACKAGECLOUD_TOKEN}:@packagecloud.io/api/v1/repos/tyk/${repo}-unstable/${distro}/${pkg_name}/promote.json") || true
+
+            if [[ "$status_code" -ne 200 && "$status_code" -ne 201 ]]; then
+              echo "::warning::Package $pkg_name not found in tyk/${repo}-unstable/${distro} (HTTP $status_code), skipping." >&2
+              rm -f "$tmp_res"
+              echo "FAILED"
+              return 0
+            fi
+
+            jq -r .download_url < "$tmp_res"
+            rm -f "$tmp_res"
           }
 
           curl_download() {
@@ -164,12 +176,15 @@ jobs:
 
                 if [[ "$repo" == "tyk-mdcb" ]]; then
                   url=$(curl_promote "$repo" "$distro" "$pkg_name")
+                  if [[ -z "$url" || "$url" == "FAILED" ]]; then
+                    continue
+                  fi
                   curl_download "$url" "$pkg_name"
                   run_cmd package_cloud yank "tyk/tyk-mdcb-stable/${distro}" "$pkg_name" || true
                   run_cmd package_cloud push "tyk/tyk-mdcb-stable/${distro}" "$pkg_name"
                   run_cmd rm -f "$pkg_name"
                 else
-                  run_cmd package_cloud promote "tyk/${repo}-unstable/${distro}" "$pkg_name" "tyk/${repo}/${distro}"
+                  run_cmd package_cloud promote "tyk/${repo}-unstable/${distro}" "$pkg_name" "tyk/${repo}/${distro}" || echo "::warning::Failed to promote $pkg_name to $distro. Skipping."
                 fi
               done
             fi
@@ -181,12 +196,15 @@ jobs:
 
                 if [[ "$repo" == "tyk-mdcb" ]]; then
                   url=$(curl_promote "$repo" "$distro" "$pkg_name")
+                  if [[ -z "$url" || "$url" == "FAILED" ]]; then
+                    continue
+                  fi
                   curl_download "$url" "$pkg_name"
                   run_cmd package_cloud yank "tyk/tyk-mdcb-stable/${distro}" "$pkg_name" || true
                   run_cmd package_cloud push "tyk/tyk-mdcb-stable/${distro}" "$pkg_name"
                   run_cmd rm -f "$pkg_name"
                 else
-                  run_cmd package_cloud promote "tyk/${repo}-unstable/${distro}" "$pkg_name" "tyk/${repo}/${distro}"
+                  run_cmd package_cloud promote "tyk/${repo}-unstable/${distro}" "$pkg_name" "tyk/${repo}/${distro}" || echo "::warning::Failed to promote $pkg_name to $distro. Skipping."
                 fi
               done
             fi


### PR DESCRIPTION
## Description

Resolves package promotion workflow failures by introducing graceful error handling and aligns parameters with the complete release matrix:

- **Graceful Promotion Error Handling:** 
  - Updated the workflow to check Packagecloud HTTP response status codes.
  - If a package is missing in unstable (e.g. FIPS variants like `tyk-sink-fips` on `s390x`), the script will output a warning and continue promoting the remaining packages rather than hard-crashing.
- **Parameterized Architectures:** Replaced the hardcoded loops for DEB (`amd64 arm64`) and RPM (`x86_64 aarch64`) with dynamic, parameterized workflow inputs `deb_arches` and `rpm_arches` (defaulting to include `s390x`).
- **Synchronized OS Distribution Defaults:** Updated `debvers` and `rpmvers` default input values to align with the complete release build matrix (adding `ubuntu/xenial`, `ubuntu/noble`, `debian/jessie`, `debian/trixie`, `el/7`, and `amazon/2`).
- **Added Multi-Package Mapping Support:** Changed the workflow variables to handle an array of package names, correctly supporting standard and FIPS packages (for MDCB, Gateway, Dashboard, Portal, and Pump) in a single run.

**Jira Ticket:** [TT-17666](https://tyktech.atlassian.net/browse/TT-17666)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- Tested locally and validated that missing packages (such as `tyk-sink-fips` on `s390x` for `2.9.1`) warn and skip correctly, allowing the rest of the packages/architectures to promote successfully.


[TT-17666]: https://tyktech.atlassian.net/browse/TT-17666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ