### PR TITLE
Add AI Studio swagger sync to tyk-docs.yml

### DIFF
--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -45,6 +45,9 @@ on:  # yamllint disable-line rule:truthy
       sync-portal:
         description: Include Portal (only swagger)
         type: boolean
+      sync-ai-studio:
+        description: Include AI Studio (only swagger)
+        type: boolean
       release:
         description: 'Release version'
         type: choice
@@ -56,6 +59,10 @@ on:  # yamllint disable-line rule:truthy
         description: 'Portal release version'
         type: string
         default: 'master'
+      ai-studio-release:
+        description: 'AI Studio release version'
+        type: string
+        default: 'main'
       source:
         description: 'Override source branch'
         default: ''
@@ -84,6 +91,7 @@ jobs:
       repoBranch: ${{ steps.collect.outputs.repoBranch }}
       jira: ${{ steps.collect.outputs.jira }}
       portalBranch: ${{ steps.collect.outputs.portalBranch }}
+      aiStudioBranch: ${{ steps.collect.outputs.aiStudioBranch }}
     steps:
       - name: Sanitize JIRA input
         run: |
@@ -133,12 +141,21 @@ jobs:
           fi
           echo "portalBranch=$portalBranch" >> $GITHUB_ENV
 
+      - name: Set AI Studio branch
+        run: |
+          aiStudioBranch="${{ github.event.inputs.ai-studio-release }}"
+          if [ -z "$aiStudioBranch" ]; then
+            aiStudioBranch="main"
+          fi
+          echo "aiStudioBranch=$aiStudioBranch" >> $GITHUB_ENV
+
       - id: collect
         run: |
              echo "jira=${{ env.jira }}" >> $GITHUB_OUTPUT
              echo "docsBranch=${{ env.docsBranch }}" >> $GITHUB_OUTPUT
              echo "repoBranch=${{ env.repoBranch }}" >> $GITHUB_OUTPUT
              echo "portalBranch=${{ env.portalBranch }}" >> $GITHUB_OUTPUT
+             echo "aiStudioBranch=${{ env.aiStudioBranch }}" >> $GITHUB_OUTPUT
   
   # Generates Tyk OAS specification & Gateway swagger
   gateway:
@@ -345,6 +362,32 @@ jobs:
           name: portal-docs
           path: portal-docs
 
+  # Generates AI Studio swagger
+  ai-studio:
+    needs: [sanitize]
+    name: AI Studio docs
+    if: ${{ github.event.inputs.sync-ai-studio == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout AI Studio
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 1
+          repository: TykTechnologies/ai-studio
+          ref: ${{ needs.sanitize.outputs.aiStudioBranch }}
+          path: ./ai-studio
+
+      - name: Generate docs
+        run: |
+          mkdir -p ai-studio-docs/
+          cp ./ai-studio/docs/swagger/swagger.yaml ai-studio-docs/ai-studio-swagger.yml
+
+      - name: Store docs
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        with:
+          name: ai-studio-docs
+          path: ai-studio-docs
+
   # Generates environment configuration docs for Gateway, Dashboard, Pump, and MDCB
   configs:
     needs: [sanitize]
@@ -425,7 +468,7 @@ jobs:
 
   finish:
     name: Open PR against tyk-docs
-    needs: [sanitize, configs, dashboard, gateway, portal]
+    needs: [sanitize, configs, dashboard, gateway, portal, ai-studio]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -477,6 +520,7 @@ jobs:
              [ -d "dashboard-docs" ] && cp dashboard-docs/opa-rules.mdx ./tyk-docs/snippets/
              [ -d "mdcb-docs" ]      && cp mdcb-docs/*.yml ./tyk-docs/swagger/
              [ -d "portal-docs" ]    && cp portal-docs/*.yaml ./tyk-docs/swagger/
+             [ -d "ai-studio-docs" ] && cp ai-studio-docs/*.yml ./tyk-docs/swagger/
              [ -d "config-docs" ]    && find config-docs -type f -exec cp {} ./tyk-docs/snippets/ \;
              true
 
@@ -496,9 +540,11 @@ jobs:
             Tyk MDCB ${{ github.event.inputs.sync-mdcb }}
             Tyk Pump ${{ github.event.inputs.sync-pump }}
             Tyk Portal: ${{ github.event.inputs.sync-portal }}
+            Tyk AI Studio: ${{ github.event.inputs.sync-ai-studio }}
 
             Intended for: ${{ github.event.inputs.release }}
             Portal release: ${{ needs.sanitize.outputs.portalBranch }}
+            AI Studio release: ${{ needs.sanitize.outputs.aiStudioBranch }}
             Changes sourced from: ${{ needs.sanitize.outputs.repoBranch }}
             Config info generator branch: ${{ env.configInfoGeneratorBranch }}
 

--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -380,7 +380,30 @@ jobs:
       - name: Generate docs
         run: |
           mkdir -p ai-studio-docs/
-          cp ./ai-studio/docs/swagger/swagger.yaml ai-studio-docs/ai-studio-swagger.yml
+
+          # ai-studio's swagger.yaml is Swagger 2.0 (OpenAPI 2.0). Mintlify does not
+          # support that version (https://www.mintlify.com/docs/api-playground/troubleshooting)
+          # and fails the whole tyk-docs deployment if it's given a 2.0 doc, so convert
+          # to OpenAPI 3.0 via SmartBear's public converter service before handing it off.
+          http_status=$(curl -sS -w "%{http_code}" -o ai-studio-docs/ai-studio-swagger.yml \
+            -X POST https://converter.swagger.io/api/convert \
+            -H "Content-Type: application/yaml" \
+            -H "Accept: application/yaml" \
+            --data-binary @./ai-studio/docs/swagger/swagger.yaml)
+
+          if [ "$http_status" != "200" ]; then
+            echo "❌ Swagger 2.0 -> OpenAPI 3.0 conversion failed (HTTP $http_status):"
+            cat ai-studio-docs/ai-studio-swagger.yml
+            exit 1
+          fi
+
+          if ! grep -q "^openapi: 3\." ai-studio-docs/ai-studio-swagger.yml; then
+            echo "❌ Converted file doesn't declare an OpenAPI 3.x version - conversion likely failed:"
+            cat ai-studio-docs/ai-studio-swagger.yml
+            exit 1
+          fi
+
+          echo "✅ Converted to OpenAPI 3.0"
 
       - name: Store docs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3


### PR DESCRIPTION
## Summary

Adds AI Studio's swagger to the `tyk-docs.yml` sync workflow (this repo's manually-triggered docs importer), alongside the existing Gateway/Dashboard/MDCB/Portal jobs.

- Source: `docs/swagger/swagger.yaml` in [TykTechnologies/ai-studio](https://github.com/TykTechnologies/ai-studio/blob/main/docs/swagger/swagger.yaml)
- Destination: `swagger/ai-studio-swagger.yml` in [TykTechnologies/tyk-docs](https://github.com/TykTechnologies/tyk-docs/blob/main/swagger/ai-studio-swagger.yml)

## Details

- New `ai-studio` job mirrors the `mdcb`/`portal` job pattern (checkout, copy, upload artifact).
- ai-studio is a public repo (like `tyk`), so its checkout needs no GitHub App token - unlike `tyk-analytics`/`tyk-sink`/`portal`, which are private.
- ai-studio has no release-branch scheme (no `release-X` branches, just `main` + feature branches), so it gets its own `ai-studio-release` input (default `main`) and `aiStudioBranch` sanitize output, following the same pattern as `portal-release`/`portalBranch` rather than reusing `repoBranch` (which assumes the gateway/dashboard/mdcb release-branch convention).
- Wired a new `sync-ai-studio` boolean input, added `ai-studio` to the `finish` job's `needs`, added the write-out line for `ai-studio-docs/*.yml`, and added AI Studio's inclusion flag + release branch to the generated tyk-docs PR body.

## OpenAPI 2.0 → 3.0 conversion (added after first real test run)

An end-to-end test sync (tyk-docs [#2580](https://github.com/TykTechnologies/tyk-docs/pull/2580)) surfaced that ai-studio's `swagger.yaml` is Swagger 2.0 (OpenAPI 2.0) format. **Mintlify does not support OpenAPI 2.0** ([confirmed via its own troubleshooting docs](https://www.mintlify.com/docs/api-playground/troubleshooting)) and failed the whole deployment with "Failed to fetch OpenAPI file for anchor or tab" when given it directly.

Fix: convert to OpenAPI 3.0 via SmartBear's public converter API (`https://converter.swagger.io/api/convert`) as part of the `Generate docs` step, before handing the file to tyk-docs. This mirrors what the file already looked like historically in tyk-docs (its stale existing copy carries an `x-original-swagger-version` field that this exact converter adds), so this isn't a new mechanism - it's restoring a conversion step that had been lost somewhere along the way.

**Tested locally against the real ai-studio spec before wiring this in:**
- HTTP 200, idempotent across repeated calls (~3.3s latency).
- All 375 operations (path + method) preserved with identical `operationId`/`summary`/`tags` post-conversion - only the envelope changes (`definitions` → `components.schemas`, `securityDefinitions` → `components.securitySchemes`, etc.), path count (268) and schema count (153) match exactly.
- Failure path verified too: invalid input returns HTTP 400 with a clear JSON error body.

The step hard-fails (checks HTTP status, then sanity-checks the output declares `openapi: 3.x`) rather than silently writing a broken or empty file if the converter service has an issue.

## Verification

- YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- This repo's only auto-triggered PR check (`exp-cmd.yml`) is path-scoped to `cmd/**` and won't run against this workflow-only change.

## Context

This closes a gap found while working DX-2380 in tyk-docs: ai-studio swagger changes (e.g. [ai-studio#385](https://github.com/TykTechnologies/ai-studio/pull/385)) had no automated path into tyk-docs at all - there was no `ai-studio` job in this workflow, so any sync had to happen by hand, and the manual sync attempt (tyk-docs #2580) is what surfaced the format problem this PR now also fixes.
