### PR TITLE
TT-17807 Add dedicated branch inputs for Pump and MDCB

### DIFF
--- a/.github/workflows/tyk-docs.yml
+++ b/.github/workflows/tyk-docs.yml
@@ -63,6 +63,14 @@ on:  # yamllint disable-line rule:truthy
         description: 'AI Studio release version'
         type: string
         default: 'main'
+      pump-release:
+        description: 'Pump release version'
+        type: string
+        default: 'master'
+      mdcb-release:
+        description: 'MDCB release version'
+        type: string
+        default: 'master'
       source:
         description: 'Override source branch'
         default: ''
@@ -92,6 +100,8 @@ jobs:
       jira: ${{ steps.collect.outputs.jira }}
       portalBranch: ${{ steps.collect.outputs.portalBranch }}
       aiStudioBranch: ${{ steps.collect.outputs.aiStudioBranch }}
+      pumpBranch: ${{ steps.collect.outputs.pumpBranch }}
+      mdcbBranch: ${{ steps.collect.outputs.mdcbBranch }}
     steps:
       - name: Sanitize JIRA input
         run: |
@@ -149,6 +159,22 @@ jobs:
           fi
           echo "aiStudioBranch=$aiStudioBranch" >> $GITHUB_ENV
 
+      - name: Set Pump branch
+        run: |
+          pumpBranch="${{ github.event.inputs.pump-release }}"
+          if [ -z "$pumpBranch" ]; then
+            pumpBranch="master"
+          fi
+          echo "pumpBranch=$pumpBranch" >> $GITHUB_ENV
+
+      - name: Set MDCB branch
+        run: |
+          mdcbBranch="${{ github.event.inputs.mdcb-release }}"
+          if [ -z "$mdcbBranch" ]; then
+            mdcbBranch="master"
+          fi
+          echo "mdcbBranch=$mdcbBranch" >> $GITHUB_ENV
+
       - id: collect
         run: |
              echo "jira=${{ env.jira }}" >> $GITHUB_OUTPUT
@@ -156,6 +182,8 @@ jobs:
              echo "repoBranch=${{ env.repoBranch }}" >> $GITHUB_OUTPUT
              echo "portalBranch=${{ env.portalBranch }}" >> $GITHUB_OUTPUT
              echo "aiStudioBranch=${{ env.aiStudioBranch }}" >> $GITHUB_OUTPUT
+             echo "pumpBranch=${{ env.pumpBranch }}" >> $GITHUB_OUTPUT
+             echo "mdcbBranch=${{ env.mdcbBranch }}" >> $GITHUB_OUTPUT
   
   # Generates Tyk OAS specification & Gateway swagger
   gateway:
@@ -313,7 +341,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
           repository: TykTechnologies/tyk-sink
-          ref: ${{ needs.sanitize.outputs.repoBranch }}
+          ref: ${{ needs.sanitize.outputs.mdcbBranch }}
           path: ./tyk-sink
 
       - name: Generate docs
@@ -466,7 +494,7 @@ jobs:
         if: ${{ github.event.inputs.sync-pump == 'true' }}
         run: |
           repo=pump
-          branch=${{ github.event.inputs.source || 'master' }}
+          branch=${{ needs.sanitize.outputs.pumpBranch }}
           dest=$GITHUB_WORKSPACE/config-docs/$repo-config.mdx
 
           sudo TOKEN=${{ steps.app-token.outputs.token }} node app.js $repo:$branch
@@ -477,7 +505,7 @@ jobs:
         if: ${{ github.event.inputs.sync-mdcb == 'true' }}
         run: |
           repo=mdcb
-          branch=${{ github.event.inputs.source || 'master' }}
+          branch=${{ needs.sanitize.outputs.mdcbBranch }}
           dest=$GITHUB_WORKSPACE/config-docs/$repo-config.mdx
 
           sudo TOKEN=${{ steps.app-token.outputs.token }} node app.js $repo:$branch
@@ -491,7 +519,7 @@ jobs:
 
   finish:
     name: Open PR against tyk-docs
-    needs: [sanitize, configs, dashboard, gateway, portal, ai-studio]
+    needs: [sanitize, configs, dashboard, gateway, mdcb, portal, ai-studio]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -568,6 +596,8 @@ jobs:
             Intended for: ${{ github.event.inputs.release }}
             Portal release: ${{ needs.sanitize.outputs.portalBranch }}
             AI Studio release: ${{ needs.sanitize.outputs.aiStudioBranch }}
+            Pump release: ${{ needs.sanitize.outputs.pumpBranch }}
+            MDCB release: ${{ needs.sanitize.outputs.mdcbBranch }}
             Changes sourced from: ${{ needs.sanitize.outputs.repoBranch }}
             Config info generator branch: ${{ env.configInfoGeneratorBranch }}
 


### PR DESCRIPTION

  ### What

  Adds two new `workflow_dispatch` inputs to the tyk-docs sync workflow, following the same pattern already used for Portal (`portal-release`)
  and AI Studio (`ai-studio-release`):

  - `pump-release` — branch of `TykTechnologies/pump` to source config docs from (default: `master`)
  - `mdcb-release` — branch of `TykTechnologies/tyk-sink` to source swagger and config docs from (default: `master`)

  ### Why

  Previously there was no way to run the docs sync against a specific Pump or MDCB branch:

  - The `mdcb` job checked out `tyk-sink` at the generic `repoBranch`, which is derived from the Gateway/Dashboard release choice and often
  doesn't exist in `tyk-sink`.
  - The Pump/MDCB config sync steps used `source || 'master'`, so the only way to change their branch was the global `source` override, which
  also redirects Gateway and Dashboard.

  With dedicated inputs, docs can be triggered from a Pump or MDCB feature/release branch without affecting the other products.

  ### Changes

  - New inputs `pump-release` and `mdcb-release` (text, default `master`)
  - `sanitize` job resolves them into `pumpBranch` / `mdcbBranch` outputs (empty input falls back to `master`)
  - `mdcb` job checks out `tyk-sink` at `mdcbBranch` instead of `repoBranch`
  - `configs` job uses `pumpBranch` / `mdcbBranch` for the Pump/MDCB config-info generator steps instead of `source || 'master'`
  - PR body of the generated tyk-docs PR now reports the Pump and MDCB branches used
  - Fix: added `mdcb` to the `finish` job's `needs` — previously `finish` could start before the MDCB job uploaded its artifact, silently
  dropping `mdcb-swagger.yml` from the resulting PR

  ### Behavior notes

  - Defaults are unchanged: leaving both inputs empty behaves exactly as before (`master`)
  - ⚠️  The global `source` override no longer affects Pump/MDCB — use the dedicated inputs instead