### PR TITLE
TT-17861 make code-freeze branch creation graceful

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -107,26 +107,43 @@ jobs:
           # Get repositories as JSON array
           REPOSITORIES='${{ steps.build-repo-list.outputs.repositories }}'
 
+          failed=0
+
           # Loop through each repository
-          echo "$REPOSITORIES" | jq -c '.[]' | while read -r repo; do
-            # Remove quotes from repo name
-            repo=$(echo "$repo" | tr -d '"')
+          for repo in $(echo "$REPOSITORIES" | jq -r '.[]'); do
             echo "Creating branch for repository: $repo"
+            remote="https://github.com/TykTechnologies/$repo.git"
+
+            # Skip if the branch already exists. Ask the remote: the clone
+            # below is shallow and single-branch, so it cannot see other refs
+            # and the push would fail with "fetch first" instead.
+            if [ -n "$(git ls-remote --heads "$remote" "refs/heads/$DEST_BRANCH")" ]; then
+              echo "Skipping $repo: $DEST_BRANCH already exists"
+              continue
+            fi
 
             # Clone repository
-            git clone --depth 1 --branch "$SOURCE_BRANCH" "https://github.com/TykTechnologies/$repo.git"
+            git clone --depth 1 --branch "$SOURCE_BRANCH" "$remote"
             cd "$repo"
-            
-            # Create and push new branch
-            git checkout -b "$DEST_BRANCH"
-            git push origin "$DEST_BRANCH"
-            
-            echo "✅ Created branch $DEST_BRANCH in $repo"
+
+            # Create and push new branch. Do not let one repository's failure
+            # abort the rest.
+            if git checkout -b "$DEST_BRANCH" && git push origin "$DEST_BRANCH"; then
+              echo "✅ Created branch $DEST_BRANCH in $repo"
+            else
+              echo "Failed to create $DEST_BRANCH in $repo"
+              failed=$((failed + 1))
+            fi
             cd ..
-            
+
             # Clean up
             rm -rf "$repo"
           done
+
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::$failed repository/repositories failed"
+            exit 1
+          fi
 
       - name: Send Slack notification
         if: ${{ github.event.inputs.notify_slack == 'true' }}

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -127,8 +127,12 @@ jobs:
             # A push that succeeds reports "new branch" for a branch that was
             # created and "up-to-date" for one that already pointed here, so
             # the exit status alone cannot tell those apart.
-            push_out=$(git push origin "HEAD:refs/heads/$DEST_BRANCH" 2>&1)
-            push_rc=$?
+            #
+            # The "|| push_rc=$?" matters: this step runs under bash -e, where
+            # a bare assignment from a failing command substitution aborts the
+            # whole step before the status can be inspected.
+            push_rc=0
+            push_out=$(git push origin "HEAD:refs/heads/$DEST_BRANCH" 2>&1) || push_rc=$?
             echo "$push_out"
 
             if [ "$push_rc" -eq 0 ]; then

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -117,7 +117,16 @@ jobs:
             # Skip if the branch already exists. Ask the remote: the clone
             # below is shallow and single-branch, so it cannot see other refs
             # and the push would fail with "fetch first" instead.
-            if [ -n "$(git ls-remote --heads "$remote" "refs/heads/$DEST_BRANCH")" ]; then
+            #
+            # Check the exit status, not just the output: ls-remote prints
+            # nothing on stdout when it fails, so an unreadable remote would
+            # otherwise look identical to "branch does not exist".
+            if ! refs=$(git ls-remote --heads "$remote" "refs/heads/$DEST_BRANCH"); then
+              echo "Failed to query $repo"
+              failed=$((failed + 1))
+              continue
+            fi
+            if [ -n "$refs" ]; then
               echo "Skipping $repo: $DEST_BRANCH already exists"
               continue
             fi

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -114,31 +114,33 @@ jobs:
             echo "Creating branch for repository: $repo"
             remote="https://github.com/TykTechnologies/$repo.git"
 
-            # Skip if the branch already exists. Ask the remote: the clone
-            # below is shallow and single-branch, so it cannot see other refs
-            # and the push would fail with "fetch first" instead.
-            #
-            # Check the exit status, not just the output: ls-remote prints
-            # nothing on stdout when it fails, so an unreadable remote would
-            # otherwise look identical to "branch does not exist".
-            if ! refs=$(git ls-remote --heads "$remote" "refs/heads/$DEST_BRANCH"); then
-              echo "Failed to query $repo"
-              failed=$((failed + 1))
-              continue
-            fi
-            if [ -n "$refs" ]; then
-              echo "Skipping $repo: $DEST_BRANCH already exists"
-              continue
-            fi
-
             # Clone repository
             git clone --depth 1 --branch "$SOURCE_BRANCH" "$remote"
             cd "$repo"
 
-            # Create and push new branch. Do not let one repository's failure
-            # abort the rest.
-            if git checkout -b "$DEST_BRANCH" && git push origin "$DEST_BRANCH"; then
-              echo "✅ Created branch $DEST_BRANCH in $repo"
+            # Push the source commit to the destination branch and let the
+            # result say what happened. Do not pre-check whether the branch
+            # exists: the clone is shallow and single-branch so it cannot see
+            # other refs, and querying the remote separately is one more call
+            # that can fail on its own and be misread.
+            #
+            # A push that succeeds reports "new branch" for a branch that was
+            # created and "up-to-date" for one that already pointed here, so
+            # the exit status alone cannot tell those apart.
+            push_out=$(git push origin "HEAD:refs/heads/$DEST_BRANCH" 2>&1)
+            push_rc=$?
+            echo "$push_out"
+
+            if [ "$push_rc" -eq 0 ]; then
+              if echo "$push_out" | grep -q "new branch"; then
+                echo "✅ Created branch $DEST_BRANCH in $repo"
+              else
+                echo "Skipping $repo: $DEST_BRANCH already up to date"
+              fi
+            elif echo "$push_out" | grep -qiE "fetch first|non-fast-forward"; then
+              # The branch exists at a different commit. Leave it alone rather
+              # than force pushing, which would discard whatever is on it.
+              echo "Skipping $repo: $DEST_BRANCH already exists"
             else
               echo "Failed to create $DEST_BRANCH in $repo"
               failed=$((failed + 1))


### PR DESCRIPTION
## Problem

Creating `release-5.15` across `tyk`, `tyk-analytics` and `tyk-analytics-ui` failed part-way through:

```
Creating branch for repository: tyk
Everything up-to-date
✅ Created branch release-5.15 in tyk          <- nothing was actually pushed

Creating branch for repository: tyk-analytics
 ! [rejected]  release-5.15 -> release-5.15 (fetch first)
error: failed to push some refs
##[error]Process completed with exit code 1    <- run dies here
```

`release-5.15` already existed on `tyk-analytics`, so the push was a non-fast-forward and git correctly refused it. `bash -e` then ended the run, and **`tyk-analytics-ui` — the one repository that genuinely needed the branch — was never reached.**

## Changes

Confined to the `Create branches` step.

**Read the push result rather than pre-checking the remote.** The push already distinguishes every case, so nothing else has to be asked:

| Result | Meaning |
|---|---|
| exit 0, output contains `new branch` | created |
| exit 0, no `new branch` | already up to date, nothing done |
| rejected with `fetch first` / `non-fast-forward` | exists at another commit, left alone |
| anything else | failure, counted |

The exit status alone is not sufficient: pushing to a branch that already points at the same commit **also** exits 0, which is exactly how the original came to print `Everything up-to-date` and `Created branch` one after the other. The output has to be inspected too.

**One repository's failure no longer aborts the rest.** Failures are counted and the loop continues; a non-zero count still fails the job at the end.

**Iterate with `for` over `jq -r` instead of piping into `while read`,** which runs the loop body in a subshell where the failure count would be discarded.

An existing branch is left alone rather than force pushed — force pushing a release branch would discard whatever is already on it.

## On not pre-checking

An earlier revision of this PR checked `git ls-remote` before cloning. In the runner that proved unreliable: it reported `Repository not found` for both private repositories one second before `git clone` succeeded against the same URL with the same token. The `url.insteadOf` rewrite applies to both commands, so the configuration is not the cause; whatever it is, a separate remote call is one more thing that can fail on its own and be misread as "the branch does not exist".

Reading the push result avoids the extra call entirely.

## Behaviour against the run that prompted this

| Repository | Before | After |
|---|---|---|
| `tyk` | ✅ printed, nothing pushed | already up to date, no false success |
| `tyk-analytics` | ❌ rejected, **run aborted** | skipped, branch already exists |
| `tyk-analytics-ui` | never reached | attempted; its ruleset block reported as a failure |

`tyk-analytics-ui` still cannot be pushed to while `Aggregated CI Status` is unsatisfied on its HEAD — that is a separate problem, tracked by the no-op PR workaround. The difference here is that it is now reported as a failure rather than hidden.

## Verification

YAML parses and `bash -n` passes on the extracted script. The classification was exercised against captured output for all six outcomes — branch absent, branch at the same commit, diverged (`non-fast-forward` and `fetch first` wordings), a `GH013` ruleset rejection, and an auth failure — and each is categorised as above.

The workflow is `workflow_dispatch` only, so nothing runs on this PR; it needs a manual dispatch to confirm end to end.