### PR TITLE
TT-18142: fix strip leading v from the promote-packages version input

### DIFF
--- a/.github/workflows/promote-packages.yml
+++ b/.github/workflows/promote-packages.yml
@@ -19,7 +19,7 @@ on:
           - all
         default: tyk-gateway
       version:
-        description: Package version to promote
+        description: Package version to promote, e.g. 5.13.2 (a leading v is stripped)
         required: true
       debvers:
         description: Space-separated Debian/Ubuntu distributions
@@ -211,7 +211,9 @@ jobs:
           }
 
           repo=$REPO
-          version=$VERSION
+          # Package filenames carry the bare version (5.13.2, not
+          # v5.13.2); a leading v in the input made every lookup miss.
+          version=${VERSION#v}
 
           repos=()
           if [[ "$repo" == "all" ]]; then


### PR DESCRIPTION
```
Package filenames carry the bare version (5.13.2, not v5.13.2), so a
v-prefixed input made every packagecloud lookup miss while the run
still reported success. This is the second time a promotion silently
failed this way (portal/pump in July, dashboard/gateway for 5.13.2).
```